### PR TITLE
FI-2688: Migrate to HL7 validator wrapper

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VALIDATOR_URL=http://localhost/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 REDIS_URL=redis://redis:6379/0
-VALIDATOR_URL=http://validator_service:4567
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
-VALIDATOR_URL=https://example.com/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false

--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -82,5 +82,21 @@ http {
 
       proxy_pass http://validator_service:4567/;
     }
+
+    location /hl7validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 600s;
+
+      proxy_pass http://hl7_validator_service:3500/;
+    }
   }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -97,5 +97,21 @@ http {
 
       proxy_pass http://validator_service:4567/;
     }
+
+    location /hl7validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 600s;
+
+      proxy_pass http://hl7_validator_service:3500/;
+    }
   }
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,5 +1,16 @@
 version: '3'
 services:
+  hl7_validator_service:
+    image: infernocommunity/inferno-resource-validator
+    environment:
+      # Defines how long validator sessions last if unused, in minutes:
+      # Negative values mean sessions never expire, 0 means sessions immediately expire
+      SESSION_CACHE_DURATION: -1
+    volumes:
+      - ./lib/inferno_template/igs:/app/igs
+      # To let the service share your local FHIR package cache,
+      # uncomment the below line
+      # - ~/.fhir:/home/ktor/.fhir
   validator_service:
     image: infernocommunity/fhir-validator-service
     # Update this path to match your directory structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
+  hl7_validator_service:
+    extends:
+      file: docker-compose.background.yml
+      service: hl7_validator_service
   validator_service:
     extends:
       file: docker-compose.background.yml

--- a/lib/inferno_template.rb
+++ b/lib/inferno_template.rb
@@ -22,8 +22,13 @@ module InfernoTemplate
     end
 
     # All FHIR validation requsets will use this FHIR validator
-    validator do
-      url ENV.fetch('VALIDATOR_URL')
+    fhir_resource_validator do
+      # igs 'identifier#version' # Use this method for published IGs/versions
+      # igs 'igs/filename.tgz'   # Use this otherwise
+
+      exclude_message do |message|
+        message.message.match?(/\A\S+: \S+: URL value '.*' does not resolve/)
+      end
     end
 
     # Tests and TestGroups can be defined inline

--- a/lib/inferno_template/igs/README.md
+++ b/lib/inferno_template/igs/README.md
@@ -1,0 +1,21 @@
+# Note on this IGs folder
+
+There are three reasons why it would be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
+
+## 1. Generated Test Suites
+Some test kits use a "generator" to automatically generate the contents of a test suite for an IG. The IG files are required every time the test suites need to be regenerated. Examples of test kits that use this approach are the US Core Test Kit and CARIN IG for Blue Button® Test Kit.
+
+
+## 2. Non-published IG
+If your IG, or the specific version of the IG you want to test against, is not published, then the validator service needs to load the IG from file in order to be able to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie:
+
+```ruby
+      fhir_resource_validator do
+        igs 'igs/filename.tgz'
+
+        ...
+      end
+```
+
+## 3. Inferno Validator UI
+The Inferno Validator UI is configured to auto-load any IGs present in the igs folder and include them in all validations. In general, the Inferno team is currently leaving IGs in this folder even if not otherwise necessary to make it easy to re-enable the validator UI.


### PR DESCRIPTION
# Summary
Migrate to the HL7 validator wrapper, as in all of our test kits. One notable difference here is the inferno validator-wrapper and validator UI are not commented out, they are left as-is, so this is mostly just addition other than changing the test suite validator block to `fhir_resource_validator`.

Corresponding changes to the docs are at: https://github.com/inferno-framework/inferno-framework.github.io/pull/32

# Testing Guidance
Sample patient tests should pass, the validator UI should still work as well at http://localhost/validator/ .
YAML to run against reference server:

```yml
- name: url
  title: FHIR Server Base Url
  type: text
  value: https://inferno.healthit.gov/reference-server/r4
- name: credentials
  optional: true
  title: OAuth Credentials
  type: oauth_credentials
  value:
    access_token: SAMPLE_TOKEN
    refresh_token: ''
    expires_in: ''
    client_id: ''
    client_secret: ''
    token_url: ''
- name: patient_id
  title: Patient ID
  type: text
  value: '85'
```