### PR TITLE
git ignore .gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .settings/org.eclipse.wst.jsdt.ui.superType.container
 .settings/org.eclipse.wst.jsdt.ui.superType.name
 .idea
+*.gem
 
 /coverage
 /spec/examples.txt


### PR DESCRIPTION
# Summary
Adding gitignore for .gem files so they do not accidentally get tracked when the template is used for new test kits
