### PR TITLE
Fix redis data permissions that prevent startup

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   hl7_validator_service:
     image: infernocommunity/inferno-resource-validator
@@ -42,5 +41,9 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - ./data/redis:/data
+      - redis_data:/data
     command: redis-server --appendonly yes
+    user: "999:999"
+
+volumes:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   inferno:
     build:
@@ -41,3 +40,6 @@ services:
     extends:
       file: docker-compose.background.yml
       service: redis
+
+volumes:
+  redis_data:


### PR DESCRIPTION
# Summary

The current main branch of inferno-template does not startup due to a redis data permission error.
The key error lines are:
```
redis-1  | 1:M 13 Nov 2025 03:51:34.612 # Can't open or create append-only dir appendonlydir: Permission denied
redis-1 exited with code 1
```

This then causes a series of startup failures which ultimately prevent the application from running.

The full error log is attached: 
[error-log.txt](https://github.com/user-attachments/files/23516308/error-log.txt)

The key issue is that Redis is trying to write to a host-mounted directory but doesn't have the proper permissions.

This has been fixed by changing the way the redis data directory is defined to be using a named Docker volume with a specific user to avoid host filesystem permission conflicts.

I also removed the obsolete version attribute from the docker-compose yamls.

# Testing Guidance

1. Running the commands `./setup.sh` and then `./run.sh` should start the application without error.
1. Navigating to `http://localhost` should present the inferno application.
